### PR TITLE
fix: use correct path to read from package.json

### DIFF
--- a/schematics/utils.ts
+++ b/schematics/utils.ts
@@ -4,15 +4,15 @@ import { Tree } from '@angular-devkit/schematics';
 
 export function getLibraryVersion() {
   return JSON.parse(
-    fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8')
+    fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8')
   ).version;
 }
 
 export function getVersionFromPackageJson(host: Tree): string {
   const sourceText = host.read('package.json')!.toString('utf-8');
-  const json = JSON.parse(sourceText);
+  const packageJson = JSON.parse(sourceText);
 
-  return json.version || '';
+  return packageJson.version || '';
 }
 
 export function addPackageToPackageJson(


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ng add schematic tries to read from package.json, but the path is not correct.

Issue Number: closes #8 

## What is the new behavior?
package.json can be read properly

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

