### PR TITLE
fix: update ng-add schematic

### DIFF
--- a/schematics/ng-add/index.ts
+++ b/schematics/ng-add/index.ts
@@ -96,7 +96,7 @@ function addDeployBuilderToProject(tree: Tree, options: NgAddOptions) {
   project.architect['deploy'] = {
     builder: 'ngx-deploy-docker:deploy',
     options: {
-      userName: options.userName
+      account: options.account
     }
   };
 

--- a/schematics/ng-add/schema.json
+++ b/schematics/ng-add/schema.json
@@ -4,11 +4,11 @@
   "title": "Add ngx-deploy-docker to Your Project",
   "type": "object",
   "properties": {
-    "userName": {
+    "account": {
       "type": "string",
-      "description": "Your Docker username",
-      "x-prompt": "What is your Docker username?",
-      "alias": "r"
+      "description": "Your Docker account",
+      "x-prompt": "What is your Docker account/username?",
+      "alias": "a"
     },
     "project": {
       "type": "string",


### PR DESCRIPTION
use 'account' instead of 'userName' in ng-add schematic

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/kauppfbi/ngx-deploy-docker/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The ng-add schematic saves the prompted username attribute as userName, but the builder expects a property called account

Issue Number: #10 

## What is the new behavior?
`--account` doesn't have to be passed in the ng deploy command. After running `ng add ...`, it is sufficient to run 'ng deploy'.
## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
